### PR TITLE
fix: Send array right form for multipart form data

### DIFF
--- a/Bappy/Infrastructure/Network/Endpoint/Requestable.swift
+++ b/Bappy/Infrastructure/Network/Endpoint/Requestable.swift
@@ -103,7 +103,13 @@ extension Requestable {
         if let bodyParameters = try bodyParameters?.toDictionary() {
             if !bodyParameters.isEmpty {
                 for (key, value) in bodyParameters {
-                    data.append(convertFormField(key: key, value: "\(value)", boundary: boundary))
+                    if let arr = value as? Array<Any> {
+                        arr.forEach { elem in
+                            data.append(convertFormField(key: key, value: "\(elem)", boundary: boundary))
+                        }
+                    } else {
+                        data.append(convertFormField(key: key, value: "\(value)", boundary: boundary))
+                    }
                 }
             }
         }


### PR DESCRIPTION
행아웃을 생성할 때, 카테고리의 경우 어레이였으나 그대로 데이터에 쓰여 "["Food"]"와 같이 데이터가 전송되는 문제가 있었습니다. 따라서 어레이로 캐스팅될 경우 이를 따로 보내줍니다.