### PR TITLE
Feature/make reviews

### DIFF
--- a/Bappy/Data/Network/APIEndpoints.swift
+++ b/Bappy/Data/Network/APIEndpoints.swift
@@ -209,13 +209,13 @@ extension APIEndpoints {
             queryParameters: filterHangoutRequestDTO)
     }
     
-    static func makeReview(with makeReviewRequestDTO: MakeReviewRequestDTO) -> Endpoint<MakeReviewResponseDTO> {
+    static func makeReviews(with makeReviewRequestDTO: MakeReviewsRequestDTO) -> Endpoint<MakeReviewResponseDTO> {
         return Endpoint(
             baseURL: BAPPY_API_BASEURL,
             path: "hangout/review",
             method: .post,
             bodyParameters: makeReviewRequestDTO,
-            contentType: .multipart)
+            contentType: .none)
     }
     
     static func fetchReviews() -> Endpoint<FetchReviewsResponseDTO> {

--- a/Bappy/Data/Network/DataMapping/Hangout/MakeReviewDTO/MakeReviewRequestDTO+Mapping.swift
+++ b/Bappy/Data/Network/DataMapping/Hangout/MakeReviewDTO/MakeReviewRequestDTO+Mapping.swift
@@ -7,9 +7,13 @@
 
 import Foundation
 
-struct MakeReviewRequestDTO: Encodable {
-    let tags: [String]
-    let message: String
-    let receiveId: String
-    let hangoutInfoId: String
+struct MakeReviewsRequestDTO: Encodable {
+    let reviews: [MakeReviewRequestDTO]
+    
+    struct MakeReviewRequestDTO: Encodable {
+        let tags: [String]
+        let message: String
+        let receiveId: String
+        let hangoutInfoId: String
+    }
 }

--- a/Bappy/Data/Repositories/DefaultHangoutRepository.swift
+++ b/Bappy/Data/Repositories/DefaultHangoutRepository.swift
@@ -407,13 +407,15 @@ extension DefaultHangoutRepository: HangoutRepository {
         //        }
     }
     
-    func makeReview(referenceModel: MakeReferenceModel, hangoutID: String) -> RxSwift.Single<Result<Bool, Error>> {
-        let requestDTO = MakeReviewRequestDTO(
-            tags: referenceModel.tags,
-            message: referenceModel.message,
-            receiveId: referenceModel.targetID,
-            hangoutInfoId: hangoutID)
-        let endpoint = APIEndpoints.makeReview(with: requestDTO)
+    func makeReviews(referenceModels: [MakeReferenceModel], hangoutID: String) -> RxSwift.Single<Result<Bool, Error>> {
+        let requestDTO = MakeReviewsRequestDTO(reviews: referenceModels.map {
+            MakeReviewsRequestDTO.MakeReviewRequestDTO(
+                tags: $0.tags,
+                message: $0.message,
+                receiveId: $0.targetID,
+                hangoutInfoId: hangoutID)
+        })
+        let endpoint = APIEndpoints.makeReviews(with: requestDTO)
         return provider.request(with: endpoint)
             .map { result -> Result<Bool, Error> in
                 switch result {

--- a/Bappy/Domain/Interfaces/Repositories/HangoutRepository.swift
+++ b/Bappy/Domain/Interfaces/Repositories/HangoutRepository.swift
@@ -22,6 +22,6 @@ protocol HangoutRepository {
     func reportHangout(hangoutID: String, reportType: String, detail: String, imageDatas: [Data]?) -> Single<Result<Bool, Error>>
     func searchHangouts(title: String) -> Single<Result<HangoutPage, Error>>
     func filterHangouts(week: [Weekday], language: [String], hangoutCategory: [Hangout.Category], startDate: Date, endDate: Date?) -> Single<Result<HangoutPage, Error>>
-    func makeReview(referenceModel: MakeReferenceModel, hangoutID: String) -> Single<Result<Bool, Error>>
+    func makeReviews(referenceModels: [MakeReferenceModel], hangoutID: String) -> Single<Result<Bool, Error>>
     func fetchReviews() -> Single<Result<[Reference], Error>>
 }

--- a/Bappy/Infrastructure/Network/Endpoint/Requestable.swift
+++ b/Bappy/Infrastructure/Network/Endpoint/Requestable.swift
@@ -41,6 +41,8 @@ extension Requestable {
         
         switch contentType {
         case .none:
+            urlRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
+            
             // httpBody
             if let bodyParameters = try bodyParameters?.toDictionary() {
                 if !bodyParameters.isEmpty {

--- a/Bappy/Presentation/Profile/WriteReview/WriteReviewViewModel.swift
+++ b/Bappy/Presentation/Profile/WriteReview/WriteReviewViewModel.swift
@@ -202,9 +202,7 @@ final class WriteReviewViewModel: ViewModelType {
                 let review = MakeReferenceModel(targetID: dependency.targetList[index].id,
                                                 tags: tags,
                                                 message: message)
-                let reviews = reviews + [review]
-
-                return dependency.hangoutRepository.makeReview(referenceModel: review, hangoutID: dependency.hangoutID)
+                return dependency.hangoutRepository.makeReviews(referenceModels: reviews + [review], hangoutID: dependency.hangoutID)
             }
             .flatMap { $0 }
             .share()
@@ -222,10 +220,6 @@ final class WriteReviewViewModel: ViewModelType {
             .bind(to: showCompleteView$)
             .disposed(by: disposeBag)
         
-//        endNowIndex
-//            .map { _ in MakeReviewCompletedViewModel(dependency: .init(user: BappyUser(id: "a", state: .normal))) }
-//            .bind(to: showCompleteView$)
-//            .disposed(by: disposeBag)
         
         // Child(Tag)
         subViewModels.reviewSelectTagViewModel.output.tags


### PR DESCRIPTION
리뷰 생성을 한 번씩 여러 번 보내는 것보다, 한 번에 여러 개를 보내는 것이 동작이 명확하고 서버 부하가 덜하므로 API를 수정했습니다.
따라서 바뀐 명세에 따라 한 번에 여러 개를 보내고, contentType은 json으로 합니다. 기존에 ".none"일 경우 리퀘스트 생성 시 contentType을 지정하지 않아 문제가 있던 것을 수정합니다.