### PR TITLE
Feature/show user

### DIFF
--- a/Bappy/Data/Network/APIEndpoints.swift
+++ b/Bappy/Data/Network/APIEndpoints.swift
@@ -16,12 +16,11 @@ struct APIEndpoints {
             method: .get)
     }
     
-    static func fetchUserProfile(with userProfileRequestDTO: FetchProfileRequestDTO) -> Endpoint<FetchProfileResponseDTO> {
+    static func fetchUserProfile(with id: String) -> Endpoint<FetchCurrentUserResponseDTO> {
         return Endpoint(
             baseURL: BAPPY_API_BASEURL,
-            path: "auth/login",
-            method: .get,
-            queryParameters: userProfileRequestDTO)
+            path: "user/\(id)",
+            method: .get)
     }
     
     static func createUser(with createUserRequestDTO: CreateUserRequestDTO) -> Endpoint<CreateUserResponseDTO> {
@@ -133,7 +132,14 @@ extension APIEndpoints {
             queryParameters: hangoutsRequestDTO)
     }
     
-    static func fetchHangouts(with fetchHangoutsOfUserRequestDTO: FetchHangoutsOfUserRequestDTO) -> Endpoint<FetchHangoutsOfUserResponseDTO> {
+    static func fetchHangouts(with fetchHangoutsOfUserRequestDTO: FetchHangoutsOfUserRequestDTO, id: String?) -> Endpoint<FetchHangoutsOfUserResponseDTO> {
+        if let id = id {
+            return Endpoint(
+                baseURL: BAPPY_API_BASEURL,
+                path: "user/\(id)/hangout",
+                method: .get,
+                queryParameters: fetchHangoutsOfUserRequestDTO)
+        }
         return Endpoint(
             baseURL: BAPPY_API_BASEURL,
             path: "user/profile/hangout",
@@ -218,7 +224,13 @@ extension APIEndpoints {
             contentType: .none)
     }
     
-    static func fetchReviews() -> Endpoint<FetchReviewsResponseDTO> {
+    static func fetchReviews(id: String?) -> Endpoint<FetchReviewsResponseDTO> {
+        if let id = id {
+            return Endpoint(
+                baseURL: BAPPY_API_BASEURL,
+                path: "user/\(id)/review",
+                method: .get)
+        }
         return Endpoint(
             baseURL: BAPPY_API_BASEURL,
             path: "hangout/review",

--- a/Bappy/Data/Network/DataMapping/User/FetchCurrentUserDTO/FetchCurrentUserResponseDTO+Mapping.swift
+++ b/Bappy/Data/Network/DataMapping/User/FetchCurrentUserDTO/FetchCurrentUserResponseDTO+Mapping.swift
@@ -11,9 +11,11 @@ import SwiftUI
 struct FetchCurrentUserResponseDTO: Decodable {
     
     let user: UserDTO
+    let message: String
     
     private enum CodingKeys: String, CodingKey {
         case user = "data"
+        case message
     }
 }
 
@@ -28,7 +30,7 @@ extension FetchCurrentUserResponseDTO {
         let introduce: String?
         let profileImageFilename: String?
         let isUserUsingGPS: Bool?
-        let state: String
+        let state: String?
         let languages: [String]?
         let personalities: [String]?
         let interests: [String]?
@@ -58,7 +60,7 @@ extension FetchCurrentUserResponseDTO {
             switch user.state {
             case "normal": return .normal
             case "notRegistered": return .notRegistered
-            default: return .notRegistered }
+            default: return message == "normal user" ? .normal : .notRegistered }
         }
         
         var gender: Gender? {

--- a/Bappy/Data/Repositories/DefaultHangoutRepository.swift
+++ b/Bappy/Data/Repositories/DefaultHangoutRepository.swift
@@ -151,15 +151,16 @@ extension DefaultHangoutRepository: HangoutRepository {
     //        }
     //    }
     
-    func fetchHangouts(profileType: Hangout.UserProfileType) -> Single<Result<[Hangout], Error>> {
+    func fetchHangouts(profileType: Hangout.UserProfileType, id: String?) -> Single<Result<[Hangout], Error>> {
         let requestDTO = FetchHangoutsOfUserRequestDTO(filter: profileType.description)
         
-        let endpoint = APIEndpoints.fetchHangouts(with: requestDTO)
+        let endpoint = APIEndpoints.fetchHangouts(with: requestDTO, id: id)
         
         return provider.request(with: endpoint)
             .map { result -> Result<[Hangout], Error> in
                 switch result {
                 case .success(let responseDTO):
+                    print("얍", responseDTO.toDomain())
                     return .success(responseDTO.toDomain())
                 case .failure(let error):
                     return .failure(error)
@@ -425,13 +426,14 @@ extension DefaultHangoutRepository: HangoutRepository {
             }
     }
     
-    func fetchReviews() -> RxSwift.Single<Result<[Reference], Error>> {
-        let endpoint = APIEndpoints.fetchReviews()
+    func fetchReviews(id: String?) -> RxSwift.Single<Result<[Reference], Error>> {
+        let endpoint = APIEndpoints.fetchReviews(id: id)
         
         return provider.request(with: endpoint)
             .map { result -> Result<[Reference], Error> in
                 switch result {
                 case .success(let responseDTO):
+                    print("얍 \(id)", responseDTO.toDomain())
                     return .success(responseDTO.toDomain())
                 case .failure(let error):
                     return .failure(error)

--- a/Bappy/Data/Repositories/DefaultUserProfileRepository.swift
+++ b/Bappy/Data/Repositories/DefaultUserProfileRepository.swift
@@ -20,8 +20,7 @@ final class DefaultUserProfileRepository {
 
 extension DefaultUserProfileRepository: UserProfileRepository {
     func fetchUserProfile(id: String) -> Single<Result<BappyUser, Error>> {
-        let requestDTO = FetchProfileRequestDTO(id: id)
-        let endpoint = APIEndpoints.fetchUserProfile(with: requestDTO)
+        let endpoint = APIEndpoints.fetchUserProfile(with: id)
         return  provider.request(with: endpoint)
             .map { result -> Result<BappyUser, Error> in
                 switch result {

--- a/Bappy/Domain/Interfaces/Repositories/HangoutRepository.swift
+++ b/Bappy/Domain/Interfaces/Repositories/HangoutRepository.swift
@@ -11,7 +11,7 @@ import RxSwift
 protocol HangoutRepository {
 //    func fetchHangouts(page: Int, sorting: Hangout.SortingOrder, category: Hangout.Category, coordinates: Coordinates?) -> Single<Result<HangoutPage, Error>>
     func fetchHangouts(page: Int, sort: Hangout.SortingOrder, categorey: Hangout.Category) -> Single<Result<HangoutPage, Error>>
-    func fetchHangouts(profileType: Hangout.UserProfileType) -> Single<Result<[Hangout], Error>> 
+    func fetchHangouts(profileType: Hangout.UserProfileType, id: String?) -> Single<Result<[Hangout], Error>> 
 //    func fetchHangouts(userID: String, profileType: Hangout.UserProfileType) -> Single<Result<[Hangout], Error>>
     func fetchHangout(hangoutID: String) -> Single<Result<Hangout, Error>>
     func createHangout(hangout: Hangout, imageData: Data) -> Single<Result<Bool, Error>>
@@ -23,5 +23,5 @@ protocol HangoutRepository {
     func searchHangouts(title: String) -> Single<Result<HangoutPage, Error>>
     func filterHangouts(week: [Weekday], language: [String], hangoutCategory: [Hangout.Category], startDate: Date, endDate: Date?) -> Single<Result<HangoutPage, Error>>
     func makeReviews(referenceModels: [MakeReferenceModel], hangoutID: String) -> Single<Result<Bool, Error>>
-    func fetchReviews() -> Single<Result<[Reference], Error>>
+    func fetchReviews(id: String?) -> Single<Result<[Reference], Error>>
 }

--- a/Bappy/Presentation/Profile/Main/ProfileViewModel.swift
+++ b/Bappy/Presentation/Profile/Main/ProfileViewModel.swift
@@ -293,7 +293,7 @@ final class ProfileViewModel: ViewModelType {
         
         // fetchJoinedHangout
         let joinedHangoutResult = startFlowWithUserID
-            .map { _ in .Joined }
+            .map { _ in (.Joined, dependency.user.id) }
             .flatMap(dependency.hangoutRepository.fetchHangouts)
             .do { [weak self] _ in self?.hideHolderView$.onNext(true) }
             .share()
@@ -310,7 +310,7 @@ final class ProfileViewModel: ViewModelType {
 
         // fetchLikedHangout
         let likedHangoutResult = startFlowWithUserID
-            .map { _ in .Liked }
+            .map { _ in (.Liked, dependency.user.id) }
             .flatMap(dependency.hangoutRepository.fetchHangouts)
             .share()
 
@@ -326,7 +326,7 @@ final class ProfileViewModel: ViewModelType {
             
         // fetchReferences
         let referenceResult = startFlowWithUserID
-            .map { _ in return Void() }
+            .map { _ in return dependency.user.id }
             .flatMap(dependency.hangoutRepository.fetchReviews)
             .share()
 


### PR DESCRIPTION
행아웃 참가자의 프로필을 확인할 수 있도록 합니다.
기존 프로필에서 행아웃, 리뷰 리스트 불러오기에 파라미터로 id를 추가합니다.
이렇게 할 경우 dependency의 user와 실제 user가 다를 수 있습니다(다른 사람의 프로필을 보는 경우).
따라서 이에 따라 행아웃 좋아요 상태를 실제 유저에 맞게 업데이트 하고, 리뷰도 실제 유저와 dependency의 유저가 다른 경우 전부 읽을 수 있도록 합니다.