### PR TITLE
Feature/home refresh

### DIFF
--- a/Bappy/Data/Network/APIEndpoints.swift
+++ b/Bappy/Data/Network/APIEndpoints.swift
@@ -124,10 +124,10 @@ extension APIEndpoints {
 
 // MARK: - Hangout
 extension APIEndpoints {
-    static func fetchHangouts(with hangoutsRequestDTO: FetchHangoutsRequestDTO) -> Endpoint<FetchHangoutsResponseDTO> {
+    static func fetchHangouts(with hangoutsRequestDTO: FetchHangoutsRequestDTO, page: Int) -> Endpoint<FetchHangoutsResponseDTO> {
         return Endpoint(
             baseURL: BAPPY_API_BASEURL,
-            path: "hangout/list/0",
+            path: "hangout/list/\(page-1)",
             method: .get,
             queryParameters: hangoutsRequestDTO)
     }

--- a/Bappy/Data/Network/DataMapping/Hangout/HangoutDTO/HangoutDTO.swift
+++ b/Bappy/Data/Network/DataMapping/Hangout/HangoutDTO/HangoutDTO.swift
@@ -73,7 +73,7 @@ extension HangoutDTO {
         }
         
         let date = meetTime.toDate(format: "yyyy-MM-dd HH:mm:ss") ?? Date()
-        let postImageURL = URL(string: "\(BAPPY_API_BASEURL)static-file/\(postImageFilename)")!
+        let postImageURL = URL(string: "\(BAPPY_API_BASEURL)static-file/\(postImageFilename)")
         let place = Hangout.Place(name: place.name, address: place.address, latitude: place.latitude, longitude: place.longitude)
         
         return Hangout(id: id,

--- a/Bappy/Data/Repositories/DefaultHangoutRepository.swift
+++ b/Bappy/Data/Repositories/DefaultHangoutRepository.swift
@@ -42,7 +42,7 @@ extension DefaultHangoutRepository: HangoutRepository {
     func fetchHangouts(page: Int, sort: Hangout.SortingOrder, categorey: Hangout.Category) -> Single<Result<HangoutPage, Error>> {
         let requestDTO = FetchHangoutsRequestDTO(hangoutSort: sort.description,
                                                  hangoutCategory: categorey.description)
-        let endpoint = APIEndpoints.fetchHangouts(with: requestDTO)
+        let endpoint = APIEndpoints.fetchHangouts(with: requestDTO, page: page)
         
         return provider.request(with: endpoint)
             .map { result -> Result<HangoutPage, Error> in

--- a/Bappy/Presentation/Home/List/HomeListViewModel.swift
+++ b/Bappy/Presentation/Home/List/HomeListViewModel.swift
@@ -190,8 +190,7 @@ final class HomeListViewModel: ViewModelType {
                 refresh$
             )
             .skip(3)
-//            .map { _ in 1 }
-            .map { _ in 0 }
+            .map { _ in 1 }
             .bind(to: page$)
             .disposed(by: disposeBag)
         
@@ -213,8 +212,7 @@ final class HomeListViewModel: ViewModelType {
         
         // Page 1보다 클 때 기존 dataSource에 추가하기
         let extraHangoutPageResult = hangoutFlow
-//            .filter { $0.0 > 1 }
-            .filter { $0.0 < -1 }
+            .filter { $0.0 > 1 }
             .flatMap(dependency.hangoutRepository.fetchHangouts)
             .observe(on: MainScheduler.asyncInstance)
             .share()
@@ -246,6 +244,7 @@ final class HomeListViewModel: ViewModelType {
             .merge(newHangoutPage, extraHangoutPage)
             .do { [weak self] _ in self?.endRefreshing$.onNext(Void()) }
             .map(\.totalPage)
+            .map { $0 / 10 + 1 }
             .bind(to: totalPage$)
             .disposed(by: disposeBag)
         
@@ -299,7 +298,7 @@ final class HomeListViewModel: ViewModelType {
                     .distinctUntilChanged()
             ) { (row: $0, count: $1) }
             .filter { $0.row == $0.count - 2 }
-            .withLatestFrom(page$)
+            .withLatestFrom(page$) { $1 }
             .withLatestFrom(totalPage$) { (page: $0, totalPage: $1) }
             .filter { $0.page < $0.totalPage }
             .map { $0.page + 1 }
@@ -318,6 +317,7 @@ final class HomeListViewModel: ViewModelType {
         Observable
             .merge(newHangoutPage, extraHangoutPage)
             .map(\.totalPage)
+            .map { $0 / 10 + 1 }
             .withLatestFrom(page$) { (totalPage: $0, page: $1) }
             .filter { $0.totalPage == $0.page }
             .map { _ in false }

--- a/Bappy/Presentation/Home/List/HomeListViewModel.swift
+++ b/Bappy/Presentation/Home/List/HomeListViewModel.swift
@@ -196,6 +196,7 @@ final class HomeListViewModel: ViewModelType {
         
         // 행아웃 불러오기 Flow
         let hangoutFlow = page$
+            .observe(on: MainScheduler.asyncInstance)
             .withLatestFrom(Observable.combineLatest(
                 sorting$,
                 category$


### PR DESCRIPTION
홈화면 페이지네이션을 정상화 합니다.
위로 끌면 데이터소스를 새로 생성하고, 아래로 끌면 과거 글들을 페이지마다 읽어 옵니다.

카테고리, 정렬 방식을 바꾸면 해당 옵션으로 다시 읽어 옵니다.