### PR TITLE
refactor|design: Show join profile images properly

### DIFF
--- a/Bappy/Presentation/Home/List/SubComponents/HangoutCell.swift
+++ b/Bappy/Presentation/Home/List/SubComponents/HangoutCell.swift
@@ -68,33 +68,10 @@ final class HangoutCell: UITableViewCell {
         return label
     }()
     
-    private let participantsImageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.contentMode = .scaleAspectFit
-        return imageView
-    }()
-    
-    private let participantsImageView2: UIImageView = {
-        let imageView = UIImageView()
-        imageView.contentMode = .scaleAspectFit
-        imageView.isHidden = true
-        return imageView
-    }()
-    
-    private let participantsImageView3: UIImageView = {
-        let imageView = UIImageView()
-        imageView.contentMode = .scaleAspectFit
-        imageView.isHidden = true
-        return imageView
-    }()
-    
-    private let participantsImageView4: UIImageView = {
-        let imageView = UIImageView()
-        imageView.image = UIImage(named: "Image 1")
-        imageView.contentMode = .scaleAspectFit
-        imageView.isHidden = true
-        return imageView
-    }()
+    private let participantsImageView = UIImageView()
+    private let participantsImageView2 = UIImageView()
+    private let participantsImageView3 = UIImageView()
+    private let participantsImageView4 = UIImageView()
     
     lazy var participantsImageViews: [UIImageView] = [participantsImageView, participantsImageView2, participantsImageView3, participantsImageView4]
     
@@ -224,36 +201,25 @@ final class HangoutCell: UITableViewCell {
             $0.height.equalTo(18.0)
         }
         
-        transparentView.addSubview(participantsImageView)
+        var before: UIView = titleLabel
+        participantsImageViews.forEach { imageView in
+            transparentView.addSubview(imageView)
+            imageView.contentMode = .scaleAspectFit
+            imageView.isHidden = true
+            imageView.layer.cornerRadius = 16.0
+            imageView.clipsToBounds = true
+            imageView.snp.makeConstraints {
+                $0.bottom.equalTo(postImageView).offset(-13.8)
+                $0.width.height.equalTo(32.0)
+                if imageView != participantsImageView {
+                    $0.leading.equalTo(before.snp.trailing).offset(12.0)
+                }
+            }
+            before = imageView
+        }
+        
         participantsImageView.snp.makeConstraints {
-            $0.bottom.equalTo(postImageView).offset(-13.8)
             $0.leading.equalTo(titleLabel).offset(6.0)
-            $0.width.equalTo(32)
-            $0.height.equalTo(32.0)
-        }
-        
-        transparentView.addSubview(participantsImageView2)
-        participantsImageView2.snp.makeConstraints {
-            $0.bottom.equalTo(postImageView).offset(-13.8)
-            $0.leading.equalTo(participantsImageView.snp.trailing).offset(12.0)
-            $0.width.equalTo(32)
-            $0.height.equalTo(32.0)
-        }
-        
-        transparentView.addSubview(participantsImageView3)
-        participantsImageView3.snp.makeConstraints {
-            $0.bottom.equalTo(postImageView).offset(-13.8)
-            $0.leading.equalTo(participantsImageView2.snp.trailing).offset(12.0)
-            $0.width.equalTo(32)
-            $0.height.equalTo(32.0)
-        }
-        
-        transparentView.addSubview(participantsImageView4)
-        participantsImageView4.snp.makeConstraints {
-            $0.bottom.equalTo(postImageView).offset(-13.8)
-            $0.leading.equalTo(participantsImageView3.snp.trailing).offset(12.0)
-            $0.width.equalTo(32)
-            $0.height.equalTo(32.0)
         }
         
         self.addSubview(moreButton)
@@ -326,7 +292,11 @@ extension HangoutCell {
         viewModel.output.joinedUsers
             .drive(onNext: { [weak self] infos in
                 for idx in 0..<infos.count {
-                    if idx == 3 { self?.participantsImageView4.isHidden = false; return }
+                    if idx == 3 {
+                        self?.participantsImageView4.image = UIImage(named: "Image 1")
+                        self?.participantsImageView4.isHidden = false
+                        return
+                    }
                     self?.participantsImageViews[idx].kf.setImage(with: infos[idx].imageURL, placeholder: UIImage(named: "profile_default"))
                     self?.participantsImageViews[idx].isHidden = false
                 }

--- a/Bappy/Presentation/Profile/Main/SubComponents/ProfileHangoutCell.swift
+++ b/Bappy/Presentation/Profile/Main/SubComponents/ProfileHangoutCell.swift
@@ -61,12 +61,12 @@ final class ProfileHangoutCell: UITableViewCell {
         return label
     }()
     
-    private let participantsImageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.image = UIImage(named: "profile_participants")
-        imageView.contentMode = .scaleAspectFit
-        return imageView
-    }()
+    private let participantsImageView = UIImageView()
+    private let participantsImageView2 = UIImageView()
+    private let participantsImageView3 = UIImageView()
+    private let participantsImageView4 = UIImageView()
+    
+    lazy var participantsImageViews: [UIImageView] = [participantsImageView, participantsImageView2, participantsImageView3, participantsImageView4]
     
     private let disabledView: UIView = {
         let disabledView = UIView()
@@ -156,12 +156,19 @@ final class ProfileHangoutCell: UITableViewCell {
             $0.centerY.equalTo(placeLabel)
         }
         
-        frameView.addSubview(participantsImageView)
-        participantsImageView.snp.makeConstraints {
-            $0.top.equalTo(placeLabel.snp.bottom).offset(8.0)
-            $0.leading.equalTo(postImageView.snp.trailing).offset(9.7)
-            $0.width.equalTo(131.0)
-            $0.height.equalTo(26.0)
+        var before = postImageView
+        participantsImageViews.forEach { imageView in
+            frameView.addSubview(imageView)
+            imageView.contentMode = .scaleAspectFit
+            imageView.isHidden = true
+            imageView.layer.cornerRadius = 16.0
+            imageView.clipsToBounds = true
+            imageView.snp.makeConstraints {
+                $0.top.equalTo(placeLabel.snp.bottom).offset(8.0)
+                $0.width.height.equalTo(32.0)
+                $0.leading.equalTo(before.snp.trailing).offset(9.7)
+            }
+            before = imageView
         }
         
         frameView.addSubview(disabledView)
@@ -183,6 +190,12 @@ extension ProfileHangoutCell {
         titleLabel.text = hangout.title
         timeLabel.text = hangout.meetTime.toString(dateFormat: "dd. MMM. HH:mm")
         placeLabel.text = hangout.place.name
+        
+        
+        for idx in 0..<min(hangout.joinedIDs.count, 4) {
+            participantsImageViews[idx].kf.setImage(with: hangout.joinedIDs[idx].imageURL, placeholder: UIImage(named: "profile_default"))
+            participantsImageViews[idx].isHidden = false
+        }
         
         disabledView.isHidden = (hangout.state == .available)
         if hangout.state != .available {


### PR DESCRIPTION
참여자들의 프로필 이미지를 사각형이 아닌 원으로 보여주며,
중복되는 코드는 묶어서 줄이도록 합니다.